### PR TITLE
Add recurring donation options to options tab

### DIFF
--- a/app/views/options/index.html.haml
+++ b/app/views/options/index.html.haml
@@ -3,9 +3,9 @@
   function showDefaultDonation(select_allow_recurring_donations) {
     var row = document.getElementById('default_donation_type_form_row');
     if (select_allow_recurring_donations.value == 'true') {
-      row.style.display = '';
+      row.style.visibility = 'visible';
     } else {
-      row.style.display = 'none';
+      row.style.visibility = 'hidden';
     }
   }
 
@@ -58,7 +58,7 @@
           = option_description_for(:allow_recurring_donations)
         .col-md-8
           = f.select :allow_recurring_donations, [['Yes', true], ['No', false]], {}, {:class => 'form-control', onchange: 'showDefaultDonation(this)'}
-      .form-row{id:"default_donation_type_form_row", style:"display: none;"}
+      .form-row{id:"default_donation_type_form_row", style:"visibility: #{@allow_recurring_donations ? 'visible' : 'hidden'}"}
         .col-md-4.text-right
           %label.col-form-label Default Donation Type
           = option_description_for(:default_donation_type)

--- a/app/views/options/index.html.haml
+++ b/app/views/options/index.html.haml
@@ -64,8 +64,8 @@
           = option_description_for(:default_donation_type)
         .col-md-8
           .radio-group.form-inline
-            = f.radio_button :default_donation_type, 'one_time', :class => 'form-control', :id => 'one_time'
-            = f.label :default_donation_type, 'One Time', :class => 'form-control', :for => 'one_time'
+            = f.radio_button :default_donation_type, 'one', :class => 'form-control', :id => 'one'
+            = f.label :default_donation_type, 'One Time', :class => 'form-control', :for => 'one'
             = f.radio_button :default_donation_type, 'monthly', :class => 'form-control', :id => 'monthly'
             = f.label :default_donation_type, 'Monthly', :class => 'form-control', :for => 'monthly'
       = render_collection_of_options f, %w( |

--- a/app/views/options/index.html.haml
+++ b/app/views/options/index.html.haml
@@ -58,7 +58,7 @@
           = option_description_for(:allow_recurring_donations)
         .col-md-8
           = f.select :allow_recurring_donations, [['Yes', true], ['No', false]], {}, {:class => 'form-control', onchange: 'showDefaultDonation(this)'}
-      .form-row{id:"default_donation_type_form_row", style:"visibility: #{@allow_recurring_donations ? 'visible' : 'hidden'}"}
+      .form-row{id:"default_donation_type_form_row", style:"visibility: #{@o.allow_recurring_donations ? 'visible' : 'hidden'}"}
         .col-md-4.text-right
           %label.col-form-label Default Donation Type
           = option_description_for(:default_donation_type)

--- a/app/views/options/index.html.haml
+++ b/app/views/options/index.html.haml
@@ -1,3 +1,14 @@
+:javascript
+  // Hide default donation type radio group unless recurring donations are allowed
+  function showDefaultDonation(select_allow_recurring_donations) {
+    var row = document.getElementById('default_donation_type_form_row');
+    if (select_allow_recurring_donations.value == 'true') {
+      row.style.display = '';
+    } else {
+      row.style.display = 'none';
+    }
+  }
+
 = form_for @o, :html => {:multipart => true, :id => 'edit_options_form'} do |f|
   .card.my-1
     .card-header.h3 Your Venue Contact Info
@@ -40,6 +51,27 @@
         quick_donation_explanation |
         quick_donation_redirect |
         donation_ack_from |
+        ) |
+      .form-row
+        .col-md-4.text-right
+          %label.col-form-label Allow Monthly Recurring Donations
+          = option_description_for(:allow_recurring_donations)
+        .col-md-8
+          = f.select :allow_recurring_donations, [['Yes', true], ['No', false]], {}, {:class => 'form-control', onchange: 'showDefaultDonation(this)'}
+      .form-row{id:"default_donation_type_form_row", style:"display: none;"}
+        .col-md-4.text-right
+          %label.col-form-label Default Donation Type
+          = option_description_for(:default_donation_type)
+        .col-md-8
+          .radio-group.form-inline
+            = f.radio_button :default_donation_type, 'one_time', :class => 'form-control', :id => 'one_time'
+            = f.label :default_donation_type, 'One Time', :class => 'form-control', :for => 'one_time'
+            = f.radio_button :default_donation_type, 'monthly', :class => 'form-control', :id => 'monthly'
+            = f.label :default_donation_type, 'Monthly', :class => 'form-control', :for => 'monthly'
+      = render_collection_of_options f, %w( |
+        recurring_donation_contact_emails |
+        notify_theatre_about_new_recurring_donation |
+        notify_threate_about_failed_recurring_donation_charge |
         ) |
 
   .card.my-1

--- a/app/views/store/donate.html.haml
+++ b/app/views/store/donate.html.haml
@@ -46,9 +46,9 @@
           .form-group.form-row
             %label.col-form-label.text-right.col-sm-6{:for => :donation} Donation frequency
             .radio-group.col-sm-6.col-md-2.form-inline
-              = radio_button_tag 'donation_type', 'one_time', Option.default_donation_type == "one_time", class: 'form-control'
+              = radio_button_tag 'donation_type', 'one', Option.default_donation_type == 'one', class: 'form-control'
               = label_tag 'donation_type_one_time', 'One Time', class: 'form-control'
-              = radio_button_tag 'donation_type', 'monthly', Option.default_donation_type == "monthly", class: 'form-control'
+              = radio_button_tag 'donation_type', 'monthly', Option.default_donation_type == 'monthly', class: 'form-control'
               = label_tag 'donation_type_monthly', 'Monthly', class: 'form-control'
         .form-group.form-row
           %label.col-form-label{:for => :donation_comments} 

--- a/app/views/store/donate.html.haml
+++ b/app/views/store/donate.html.haml
@@ -42,6 +42,14 @@
             = text_field_tag 'donation', @amount, :type => :number, :class => 'text-right form-control form-control-sm'
             .input-group-append
               %span.input-group-text.form-control-sm .00
+        - if Option.allow_recurring_donations
+          .form-group.form-row
+            %label.col-form-label.text-right.col-sm-6{:for => :donation} Donation frequency
+            .radio-group.col-sm-6.col-md-2.form-inline
+              = radio_button_tag 'donation_type', 'one_time', Option.default_donation_type == "one_time", class: 'form-control'
+              = label_tag 'donation_type_one_time', 'One Time', class: 'form-control'
+              = radio_button_tag 'donation_type', 'monthly', Option.default_donation_type == "monthly", class: 'form-control'
+              = label_tag 'donation_type_monthly', 'Monthly', class: 'form-control'
         .form-group.form-row
           %label.col-form-label{:for => :donation_comments} 
             If you'd like to be recognized as Anonymous, or if you'd like to donate in honor

--- a/config/locales/en.option_descriptions.yml
+++ b/config/locales/en.option_descriptions.yml
@@ -484,3 +484,26 @@ en:
       https.  NOTE: Audience1st will also try to serve your
       favicon.ico from the same directory that contains the stylesheet; if
       no favicon.ico is found there, a generic one will be served.
+
+    allow_recurring_donations: >
+
+      Whether to allow customers to initiate recurring monthly donations.
+
+    default_donation_type: >
+
+      Default donation type to be checked when a customer is on the 'make donation' page.
+
+    recurring_donation_contact_emails: >
+
+      Comma-separated list of theatre contact email addresses to contact
+      regarding recurring donation activity.
+
+    notify_theatre_about_new_recurring_donation: >
+      
+      Whether to notify theatre contact email addresses when a customer initiates
+      a new recurring donation.
+
+    notify_threate_about_failed_recurring_donation_charge: >
+
+      Whether to notify theatre contact email addresses when a charge from an
+      existing recurring donation fails.

--- a/db/migrate/20240225093946_add_recurring_donation_options_to_options_table.rb
+++ b/db/migrate/20240225093946_add_recurring_donation_options_to_options_table.rb
@@ -1,7 +1,7 @@
 class AddRecurringDonationOptionsToOptionsTable < ActiveRecord::Migration
   def change
     add_column :options, :allow_recurring_donations, :boolean, default: false
-    add_column :options, :default_donation_type, :string, default: "One Time"
+    add_column :options, :default_donation_type, :string, default: "one"
     add_column :options, :recurring_donation_contact_emails, :text
     add_column :options, :notify_theatre_about_new_recurring_donation, :boolean, default: true
     add_column :options, :notify_threate_about_failed_recurring_donation_charge, :boolean, default: true

--- a/db/migrate/20240225093946_add_recurring_donation_options_to_options_table.rb
+++ b/db/migrate/20240225093946_add_recurring_donation_options_to_options_table.rb
@@ -1,0 +1,9 @@
+class AddRecurringDonationOptionsToOptionsTable < ActiveRecord::Migration
+  def change
+    add_column :options, :allow_recurring_donations, :boolean, default: false
+    add_column :options, :default_donation_type, :string, default: "One Time"
+    add_column :options, :recurring_donation_contact_emails, :text
+    add_column :options, :notify_theatre_about_new_recurring_donation, :boolean, default: true
+    add_column :options, :notify_threate_about_failed_recurring_donation_charge, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20231229020410) do
+ActiveRecord::Schema.define(version: 20240225093946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,6 +198,11 @@ ActiveRecord::Schema.define(version: 20231229020410) do
     t.text     "general_reminder_email_notes"
     t.integer  "import_timeout",                                                     default: 15,                                                                                                                              null: false
     t.string   "transactional_bcc_email"
+    t.boolean  "allow_recurring_donations",                                          default: false
+    t.string   "default_donation_type",                                              default: "One Time"
+    t.text     "recurring_donation_contact_emails"
+    t.boolean  "notify_theatre_about_new_recurring_donation",                        default: true
+    t.boolean  "notify_threate_about_failed_recurring_donation_charge",              default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -199,7 +199,7 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.integer  "import_timeout",                                                     default: 15,                                                                                                                              null: false
     t.string   "transactional_bcc_email"
     t.boolean  "allow_recurring_donations",                                          default: false
-    t.string   "default_donation_type",                                              default: "One Time"
+    t.string   "default_donation_type",                                              default: "one"
     t.text     "recurring_donation_contact_emails"
     t.boolean  "notify_theatre_about_new_recurring_donation",                        default: true
     t.boolean  "notify_threate_about_failed_recurring_donation_charge",              default: true


### PR DESCRIPTION
1. Create migration file to add new recurring donation options to options table.
2. Run migration to update schema.rb file.
3. Add recurring donation options UI fields to donations card in options tab.
4. Make default donation type radio group appear only when recurring donations are allowed.
5. Add option descriptions.

- Add donation frequency radio group to 'make donation' page.
-- note: this is part of a different feature (donate page), but i accidentally merged that feature branch into this one, and idk how to remove it, so i just left it in here to be merged with this feature