### PR TITLE
Update options tab controller action

### DIFF
--- a/app/controllers/options_controller.rb
+++ b/app/controllers/options_controller.rb
@@ -1,7 +1,7 @@
 class OptionsController < ApplicationController
 
   before_filter :is_admin_filter
-  
+
   def index
     @o = Option.first
   end
@@ -15,6 +15,8 @@ class OptionsController < ApplicationController
       option_params['advance_sales_cutoff'].to_i * params['before_or_after'].to_i
     # if there is a file upload for HTML template, get it
     option_params['html_email_template'] = params['html_email_template'].read unless params['html_email_template'].blank?
+    # if recurring donations not allowed, set default_donation_type to one time
+    option_params['default_donation_type'] = 'one' unless option_params['allow_recurring_donations'] == 'true'
     if (@o.update_attributes(option_params))
       redirect_to options_path, :notice => "Update successful."
     else

--- a/app/views/store/donate.html.haml
+++ b/app/views/store/donate.html.haml
@@ -46,10 +46,10 @@
           .form-group.form-row
             %label.col-form-label.text-right.col-sm-6{:for => :donation} Donation frequency
             .radio-group.col-sm-6.col-md-2.form-inline
-              = radio_button_tag 'donation_type', 'one', Option.default_donation_type == 'one', class: 'form-control'
-              = label_tag 'donation_type_one_time', 'One Time', class: 'form-control'
-              = radio_button_tag 'donation_type', 'monthly', Option.default_donation_type == 'monthly', class: 'form-control'
-              = label_tag 'donation_type_monthly', 'Monthly', class: 'form-control'
+              = radio_button_tag 'donation_type', 'one', Option.default_donation_type == 'one', class: 'form-control', id: 'one'
+              = label_tag 'donation_type_one_time', 'One Time', class: 'form-control', for: 'one'
+              = radio_button_tag 'donation_type', 'monthly', Option.default_donation_type == 'monthly', class: 'form-control', id: 'monthly'
+              = label_tag 'donation_type_monthly', 'Monthly', class: 'form-control', for: 'monthly'
         .form-group.form-row
           %label.col-form-label{:for => :donation_comments} 
             If you'd like to be recognized as Anonymous, or if you'd like to donate in honor


### PR DESCRIPTION
1. Update options tab 'update' controller action to set default donation type to one-time if recurring donations not allowed
2. Quality of life update to radio buttons on donate page (make them react to clicking on labels)