### PR TITLE
fixes error message associated with running seed task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -79,7 +79,8 @@ class Audience1stSeeder
   end
 
   def self.create_default_seating_zone
-    SeatingZone.create!(name: 'Reserved', short_name: 'res')
+    zone_params = {name: 'Reserved', short_name: 'res'}
+    SeatingZone.create!(zone_params) unless SeatingZone.find_by(zone_params)
   end
   
   def self.create_options


### PR DESCRIPTION
Seed task now only creates default seating zone if it doesn't already exist, making seeding idempotent again.  Doesn't affect tests, since every test truncates the database anyway. (In practice, this wasn't affecting proper seeding since the seating zone is the last thing seeded, so by the time the error happened all the other seeding was done)