### PR TITLE
added test

### DIFF
--- a/features/donations/monthly_donation_user_view.feature
+++ b/features/donations/monthly_donation_user_view.feature
@@ -4,13 +4,17 @@ Background:
   Given I am logged in as customer "Tom Foolery"
   Given admin "has" allowed recurring donations
   And I go to the quick donation page
-
-@stubs_successful_credit_card_payment
-Scenario: make donation
   Then I should see "frequency"
   When I select monthly in the donation frequency radio button
   When I fill in "Donation amount" with "15"
+
+@stubs_successful_credit_card_payment
+Scenario: make donation
   And I press "Charge Donation to Credit Card"
   Then I should see "You have paid a total of $15.00 by Credit card"
   Then there should be a Recurring Donation model instance belonging to "Tom Foolery"
-  
+
+@stubs_failed_credit_card_payment
+Scenario: attempt to make a donation but card payment fails
+  And I press "Charge Donation to Credit Card"
+  Then there should not be a Recurring Donation model instance belonging to "Tom Foolery"

--- a/features/donations/monthly_donation_user_view.feature
+++ b/features/donations/monthly_donation_user_view.feature
@@ -7,14 +7,13 @@ Background:
   Then I should see "frequency"
   When I select monthly in the donation frequency radio button
   When I fill in "Donation amount" with "15"
+  And I press "Charge Donation to Credit Card"
 
 @stubs_successful_credit_card_payment
 Scenario: make donation
-  And I press "Charge Donation to Credit Card"
   Then I should see "You have paid a total of $15.00 by Credit card"
   Then there should be a Recurring Donation model instance belonging to "Tom Foolery"
 
 @stubs_failed_credit_card_payment
 Scenario: attempt to make a donation but card payment fails
-  And I press "Charge Donation to Credit Card"
   Then there should not be a Recurring Donation model instance belonging to "Tom Foolery"

--- a/features/step_definitions/option_steps.rb
+++ b/features/step_definitions/option_steps.rb
@@ -72,3 +72,6 @@
    expect(c.first_name).to eq(first)
    expect(c.last_name).to eq(last)
   end
+  Then /there should not be a Recurring Donation model instance belonging to "(.*) (.*)"$/ do |first,last|
+    expect(RecurringDonation.first).to eq(nil)
+   end


### PR DESCRIPTION
> ok, so basically a recurring donation when first set up causes both a regular donation to be processed and a new record to be added to RecurringDonations table?  so questions: (a) for the Cuke test that tests this, can you use @stubs_successful_credit_card_payment (see features/support/env.rb) rather than stubbing Stripe::Charge.create
> directly; and (b) are there tests for the failure cases?  handling failures on this is really important:
> (a) what if the stripe charge fails? (the recurring donation should not be created, and the donation should not be recorded)
> (b) what if creating the recurring donation fails? (the stripe charge should not occur for the initial donation)
> not sure i saw scenarios/specs that covered the sad paths but they are pretty important... they can be a separate PR but i'm reluctant to incorporate code whose failure behavior is so critical unless the tests are pretty thorough....

Attempted to handle Armando's requests. 
- We are already using @stubs_successful_credit_card_payment 
- I think I solved (a)
- Not sure about (b)

Run the test with:
`RUBYOPT="-W0" bundle exec cucumber features/donations/monthly_donation_user_view.feature `